### PR TITLE
Support Chelsio T4/T5/T6 VF in SRIOV mode

### DIFF
--- a/buildroot-external/board/pc/ova/kernel.config
+++ b/buildroot-external/board/pc/ova/kernel.config
@@ -121,6 +121,7 @@ CONFIG_IXGBEVF=m
 CONFIG_I40EVF=m
 CONFIG_MLX5_CORE=m
 CONFIG_MLX5_CORE_EN=y
+CONFIG_CHELSIO_T4VF=m
 
 # x86-specific network driver, requires more options from device-support.config fragment
 CONFIG_DWMAC_INTEL=m


### PR DESCRIPTION
This change supports in kernel drivers for Chelsio T4, T5 & T6 adapters with PCI-E SR-IOV Virtual Functions.